### PR TITLE
Fixed: the issue of empty chips on UI on inProgress page(#119)

### DIFF
--- a/src/services/UtilService.ts
+++ b/src/services/UtilService.ts
@@ -151,7 +151,7 @@ const findCarrierShipmentBoxType = async(carrierPartyIds: Array<string>): Promis
       "partyId_op": "in"
     },
     "fieldList": ["shipmentBoxTypeId", "partyId"],
-    "viewSize": carrierPartyIds.length,
+    "viewSize": carrierPartyIds.length * 10,  // considering that one carrierPartyId will have maximum of 10 box type
   }
 
   try {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #119 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
The issue is as when fetching boxType information for carrierPartyId, all the box type information for carrierParty is not getting fetched due to wrong viewSize

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)