### PR TITLE
Fixed: issue of unwanted api calls after login, due to change in facility and productStore

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -263,6 +263,11 @@ export default defineComponent({
       })
     },
     async setFacility (facility: any) {
+      // not updating the facility when the current facility in vuex state and the selected facility are same
+      if(this.currentFacility.facilityId === facility['detail'].value) {
+        return;
+      }
+
       if (this.userProfile){
         await this.store.dispatch('user/setFacility', {
           'facility': this.userProfile.facilities.find((fac: any) => fac.facilityId == facility['detail'].value)
@@ -412,6 +417,11 @@ export default defineComponent({
       await alert.present();
     },
     async setEComStore(store: any) {
+      // not updating the ecomstore when the current value in vuex state and selected value are same
+      if(this.currentEComStore.productStoreId === store['detail'].value) {
+        return;
+      }
+
       if(this.userProfile) {
         await this.store.dispatch('user/setEComStore', {
           'eComStore': this.userProfile.stores.find((str: any) => str.productStoreId == store['detail'].value)

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -262,15 +262,15 @@ export default defineComponent({
         this.router.push('/login');
       })
     },
-    async setFacility (facility: any) {
+    async setFacility (event: any) {
       // not updating the facility when the current facility in vuex state and the selected facility are same
-      if(this.currentFacility.facilityId === facility['detail'].value) {
+      if(this.currentFacility.facilityId === event.detail.value) {
         return;
       }
 
       if (this.userProfile){
         await this.store.dispatch('user/setFacility', {
-          'facility': this.userProfile.facilities.find((fac: any) => fac.facilityId == facility['detail'].value)
+          'facility': this.userProfile.facilities.find((fac: any) => fac.facilityId == event.detail.value)
         });
         this.store.dispatch('order/clearOrders')
         this.getCurrentFacilityDetails();
@@ -416,15 +416,15 @@ export default defineComponent({
 
       await alert.present();
     },
-    async setEComStore(store: any) {
+    async setEComStore(event: any) {
       // not updating the ecomstore when the current value in vuex state and selected value are same
-      if(this.currentEComStore.productStoreId === store['detail'].value) {
+      if(this.currentEComStore.productStoreId === event.detail.value) {
         return;
       }
 
       if(this.userProfile) {
         await this.store.dispatch('user/setEComStore', {
-          'eComStore': this.userProfile.stores.find((str: any) => str.productStoreId == store['detail'].value)
+          'eComStore': this.userProfile.stores.find((str: any) => str.productStoreId == event.detail.value)
         })
         this.getOutstandingOrdersCount();
         this.getInProgressOrdersCount();


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
On login, api calls to get the count of inProgress and outstanding orders is being made, as after login we set the facility and eComStore that results in calling the apis.

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added condition to check for values in state and current selected value and if both are same not making api calls.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)