### PR TITLE
Fixed: searching on some fields not working on open orders page(#162)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -214,7 +214,6 @@ const actions: ActionTree<OrderState, RootState> = {
         ...payload,
         queryString: inProgressQuery.queryString,
         viewSize: inProgressQuery.viewSize,
-        queryFields: 'productId productName virtualProductName orderId search_orderIdentifications productSku customerId customerName goodIdentifications',
         sort: 'orderDate asc',
         groupBy: 'picklistBinId',
         filters: {
@@ -352,7 +351,6 @@ const actions: ActionTree<OrderState, RootState> = {
       ...payload,
       queryString: completedOrderQuery.queryString,
       viewSize: completedOrderQuery.viewSize,
-      queryFields: 'productId productName virtualProductName orderId search_orderIdentifications productSku customerId customerName goodIdentifications',
       groupBy: 'picklistBinId',
       sort: 'orderDate asc',
       filters: {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -299,7 +299,6 @@ const actions: ActionTree<OrderState, RootState> = {
       ...payload,
       queryString: openOrderQuery.queryString,
       viewSize: openOrderQuery.viewSize,
-      queryFields: 'orderId',
       filters: {
         quantityNotAvailable: { value: 0 },
         isPicked: { value: 'N' },

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -365,7 +365,6 @@ export default defineComponent({
     async fetchShipmentMethods() {
       const payload = prepareOrderQuery({
         viewSize: "0",  // passing viewSize as 0, as we don't want to fetch any data
-        queryFields: 'productId productName virtualProductName orderId search_orderIdentifications productSku customerId customerName goodIdentifications',
         groupBy: 'picklistBinId',
         sort: 'orderDate asc',
         defType: "edismax",
@@ -407,7 +406,6 @@ export default defineComponent({
     async fetchCarrierPartyIds() {
       const payload = prepareOrderQuery({
         viewSize: "0",  // passing viewSize as 0, as we don't want to fetch any data
-        queryFields: 'productId productName virtualProductName orderId search_orderIdentifications productSku customerId customerName goodIdentifications',
         groupBy: 'picklistBinId',
         sort: 'orderDate asc',
         defType: "edismax",


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #162 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed passing queryFields params when preparing the query, as when the queryFields are not passed by default searching works on `productId productName virtualProductName orderId productSku customerId customerName search_orderIdentifications goodIdentifications`

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

After:

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/d1e69a3f-a3c2-41b5-b4af-fc15bda50cd0)

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/0386fa94-f3df-49f2-8c77-f015a57fd549)

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/d713e593-9abf-4507-8924-9e7247f70a29)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)