### PR TITLE
Fixed: select all button to be disabled when there are no fields available for mapping(160)

### DIFF
--- a/src/views/DownloadPackedOrders.vue
+++ b/src/views/DownloadPackedOrders.vue
@@ -14,7 +14,7 @@
       <main>
         <ion-list>
           <ion-list-header>{{ $t("Select the fields you want to include in your export") }}</ion-list-header>
-          <ion-button fill="clear" @click="selectAll" >{{ $t('Select all') }}</ion-button>
+          <ion-button fill="clear" @click="selectAll" :disabled="!Object.keys(fieldMapping).length">{{ $t('Select all') }}</ion-button>
 
           <ion-item :key="field" v-for="(value, field) in fieldMapping">
             <ion-checkbox :checked="selectedData[field]" @click="isFieldClicked=true" @ionChange="updateSelectedData(field)" slot="start"/>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #160 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added a check, that if there are no fields available, then disable the select all button.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

After:

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/4f5dd99f-7179-4b3f-a43f-3e37f20654f6)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)