### PR TITLE
Fixed: issue of menu not being enabled for the correct page when using the back button(#137)

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -11,7 +11,6 @@
         <ion-menu-toggle auto-hide="false" v-for="(page, index) in appPages" :key="index">
           <ion-item
             button
-            @click="selectedIndex = index"
             router-direction="root"
             :router-link="page.url"
             class="hydrated"
@@ -38,10 +37,11 @@ import {
   IonTitle,
   IonToolbar
 } from "@ionic/vue";
-import { defineComponent, ref } from "vue";
+import { computed, defineComponent } from "vue";
 import { mapGetters } from "vuex";
 import { mailUnreadOutline, mailOpenOutline, checkmarkDoneOutline, settingsOutline, swapVerticalOutline } from "ionicons/icons";
 import { useStore } from "@/store";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "Menu",
@@ -57,29 +57,16 @@ export default defineComponent({
     IonTitle,
     IonToolbar
   },
-  created() {
-    // When open any specific screen it should show that screen selected
-    this.selectedIndex = this.appPages.findIndex((screen) => {
-      return screen.url === this.$router.currentRoute.value.path;
-    })
-  },
   computed: {
     ...mapGetters({
       isUserAuthenticated: 'user/isUserAuthenticated',
       currentFacility: 'user/getCurrentFacility',
     })
   },
-  watch:{
-    $route (to) {
-      // When logout and login it should point to Oth index
-      if (to.path === '/login') {
-        this.selectedIndex = 0;
-      }
-    },
-  }, 
   setup() {
     const store = useStore();
-    const selectedIndex = ref(0);
+    const router = useRouter();
+
     const appPages = [
       {
         title: "Open",
@@ -104,14 +91,21 @@ export default defineComponent({
         url: "/exim",
         iosIcon: swapVerticalOutline,
         mdIcon: swapVerticalOutline,
+        childRoutes: ["/download-packed-orders", "/upload-import-orders"] // defined child routes as to enable the correct menu when we are on a route that is not listed in the menu
       },
       {
         title: "Settings",
         url: "/settings",
         iosIcon: settingsOutline,
         mdIcon: settingsOutline,
-      },
+      }
     ];
+
+    const selectedIndex = computed(() => {
+      const path = router.currentRoute.value.path
+      return appPages.findIndex((screen) => screen.url === path || screen.childRoutes?.includes(path))
+    })
+
     return {
       selectedIndex,
       appPages,
@@ -121,7 +115,7 @@ export default defineComponent({
       settingsOutline,
       store
     };
-  },
+  }
 });
 </script>
 


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #137 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed a watcher from the menu component that checks for route changes
- Defined a computed property to find the correct index in the menu list
- Added an entry in the menu component pages to list all the child routes those are not listed in the menu for a specific parent route, using which we have enabled the correct menu in the UI.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

https://github.com/hotwax/fulfillment-pwa/assets/41404838/a4556d47-6807-466a-8fc7-21425057a3eb


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)