### PR TITLE
Implemented: support to display a spinner on document printing buttons(#176)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -407,7 +407,9 @@ const actions: ActionTree<OrderState, RootState> = {
         items: order.doclist.docs,
         shipmentId: orderItem.shipmentId,
         shipmentMethodTypeId: orderItem.shipmentMethodTypeId,
-        shipmentMethodTypeDesc: orderItem.shipmentMethodTypeDesc
+        shipmentMethodTypeDesc: orderItem.shipmentMethodTypeDesc,
+        isGeneratingShippingLabel: false,
+        isGeneratingPackingSlip: false
       }
     })
 

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -99,8 +99,14 @@
                 <ion-button  :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" @click="shipOrder(order)" v-else>{{ $t("Ship Now") }}</ion-button>
                 <!-- TODO: implemented support to make the buttons functional -->
                 <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" v-if="order.missingLabelImage" fill="outline" @click="retryShippingLabel(order)">{{ $t("Retry Generate Label") }}</ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" v-else fill="outline" @click="printShippingLabel(order)">{{ $t("Print Shipping Label") }}</ion-button>
-                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click="printPackingSlip(order)">{{ $t("Print Customer Letter") }}</ion-button>
+                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" v-else fill="outline" @click="printShippingLabel(order)">
+                  {{ $t("Print Shipping Label") }}
+                  <ion-spinner color="primary" slot="end" v-if="order.isGeneratingShippingLabel" name="crescent" />
+                </ion-button>
+                <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo" fill="outline" @click="printPackingSlip(order)">
+                  {{ $t("Print Customer Letter") }}
+                  <ion-spinner color="primary" slot="end" v-if="order.isGeneratingPackingSlip" name="crescent" />
+                </ion-button>
               </div>
               <div class="desktop-only">
                 <ion-button :disabled="order.hasMissingShipmentInfo || order.hasMissingPackageInfo || !hasPackedShipments(order)" fill="outline" color="danger" @click="unpackOrder(order)">{{ $t("Unpack") }}</ion-button>
@@ -144,6 +150,7 @@ import {
   IonMenuButton,
   IonPage,
   IonSearchbar,
+  IonSpinner,
   IonThumbnail,
   IonTitle,
   IonToolbar,
@@ -187,6 +194,7 @@ export default defineComponent({
     IonMenuButton,
     IonPage,
     IonSearchbar,
+    IonSpinner,
     IonThumbnail,
     IonTitle,
     IonToolbar,
@@ -537,12 +545,28 @@ export default defineComponent({
       }
     },
     async printPackingSlip(order: any) {
+      // if the request to print packing slip is not yet completed, then clicking multiple times on the button
+      // should not do anything
+      if(order.isGeneratingPackingSlip) {
+        return;
+      }
+
       const shipmentIds = order.shipments.map((shipment: any) => shipment.shipmentId)
+      order.isGeneratingPackingSlip = true;
       await OrderService.printPackingSlip(shipmentIds);
+      order.isGeneratingPackingSlip = false;
     },
     async printShippingLabel(order: any) {
+      // if the request to print shipping label is not yet completed, then clicking multiple times on the button
+      // should not do anything
+      if(order.isGeneratingShippingLabel) {
+        return;
+      }
+
       const shipmentIds = order.shipments.map((shipment: any) => shipment.shipmentId)
+      order.isGeneratingShippingLabel = true;
       await OrderService.printShippingLabel(shipmentIds)
+      order.isGeneratingShippingLabel = false;
     }
   },
   setup() {

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -27,7 +27,7 @@
               {{ picklist.pickersName }}
               <p>{{ picklist.date }}</p>
             </ion-label>
-            <ion-spinner color="primary" slot="end" v-if="picklist.isGeneratingDocument" name="crescent" />
+            <ion-spinner color="primary" slot="end" v-if="picklist.isGeneratingPicklist" name="crescent" />
             <ion-button v-else fill="outline" slot="end" @click="printPicklist(picklist)">
               <ion-icon :icon="printOutline" />
             </ion-button>
@@ -254,7 +254,6 @@ export default defineComponent({
       picklists: [] as any,
       defaultShipmentBoxType: '',
       itemsIssueSegmentSelected: [] as any,
-      isGeneratingDocument: false as boolean
     }
   },
   methods: {
@@ -622,7 +621,7 @@ export default defineComponent({
                 id: picklist.picklistId,
                 pickersName: pickersName.join(', '),
                 date: DateTime.fromMillis(picklist.picklistDate).toLocaleString(DateTime.TIME_SIMPLE),
-                isGeneratingDocument: false  // used to display the spinner on the button when trying to generate picklist
+                isGeneratingPicklist: false  // used to display the spinner on the button when trying to generate picklist
               })
 
               return picklists
@@ -764,9 +763,9 @@ export default defineComponent({
       await this.updateOrderQuery(process.env.VUE_APP_VIEW_SIZE, '')
     },
     async printPicklist(picklist: any) {
-      picklist.isGeneratingDocument = true;
+      picklist.isGeneratingPicklist = true;
       await OrderService.printPicklist(picklist.id)
-      picklist.isGeneratingDocument = false;
+      picklist.isGeneratingPicklist = false;
     }
   },
   async mounted () {

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -27,7 +27,10 @@
               {{ picklist.pickersName }}
               <p>{{ picklist.date }}</p>
             </ion-label>
-            <ion-button fill="outline" slot="end" @click="printPicklist(picklist.id)"><ion-icon :icon="printOutline" /></ion-button>
+            <ion-spinner color="primary" slot="end" v-if="picklist.isGeneratingDocument" name="crescent" />
+            <ion-button v-else fill="outline" slot="end" @click="printPicklist(picklist)">
+              <ion-icon :icon="printOutline" />
+            </ion-button>
           </ion-item>
         </div>
 
@@ -181,6 +184,7 @@ import {
   IonSelect,
   IonSelectOption,
   IonSkeletonText,
+  IonSpinner,
   IonThumbnail,
   IonTitle,
   IonToolbar,
@@ -229,6 +233,7 @@ export default defineComponent({
     IonSelect,
     IonSelectOption,
     IonSkeletonText,
+    IonSpinner,
     IonThumbnail,   
     IonTitle,
     IonToolbar,
@@ -249,6 +254,7 @@ export default defineComponent({
       picklists: [] as any,
       defaultShipmentBoxType: '',
       itemsIssueSegmentSelected: [] as any,
+      isGeneratingDocument: false as boolean
     }
   },
   methods: {
@@ -615,7 +621,8 @@ export default defineComponent({
               picklists.push({
                 id: picklist.picklistId,
                 pickersName: pickersName.join(', '),
-                date: DateTime.fromMillis(picklist.picklistDate).toLocaleString(DateTime.TIME_SIMPLE)
+                date: DateTime.fromMillis(picklist.picklistDate).toLocaleString(DateTime.TIME_SIMPLE),
+                isGeneratingDocument: false  // used to display the spinner on the button when trying to generate picklist
               })
 
               return picklists
@@ -756,8 +763,10 @@ export default defineComponent({
     async initialiseOrderQuery() {
       await this.updateOrderQuery(process.env.VUE_APP_VIEW_SIZE, '')
     },
-    async printPicklist(picklistId: string) {
-      await OrderService.printPicklist(picklistId)
+    async printPicklist(picklist: any) {
+      picklist.isGeneratingDocument = true;
+      await OrderService.printPicklist(picklist.id)
+      picklist.isGeneratingDocument = false;
     }
   },
   async mounted () {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #176

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Added spinner so that the user knows that some process is going on in background.
- Added the spinner in the end where the button is having some label, and if the button is having an icon then replacing the button with the spinner

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)