### PR TITLE
Implemented: support to display the picker id below picker name in the assign picker modal on open page(#183)

### DIFF
--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -27,7 +27,10 @@
       <div v-if="!pickers.length">{{ 'No picker found' }}</div>
       <div v-else>
         <ion-item v-for="(picker, index) in pickers" :key="index" @click="selectPicker(picker.id)">
-          <ion-label>{{ picker.name }}</ion-label>
+          <ion-label>
+            {{ picker.name }}
+            <p>{{ picker.id }}</p>
+          </ion-label>
           <ion-checkbox :checked="isPickerSelected(picker.id)"/>
         </ion-item>
       </div>

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -29,7 +29,7 @@
         <ion-item v-for="(picker, index) in pickers" :key="index" @click="selectPicker(picker.id)">
           <ion-label>
             {{ picker.name }}
-            <p>{{ picker.externalId }}</p>
+            <p>{{ picker.externalId ? picker.externalId : picker.id }}</p>
           </ion-label>
           <ion-checkbox :checked="isPickerSelected(picker.id)"/>
         </ion-item>

--- a/src/views/AssignPickerModal.vue
+++ b/src/views/AssignPickerModal.vue
@@ -29,7 +29,7 @@
         <ion-item v-for="(picker, index) in pickers" :key="index" @click="selectPicker(picker.id)">
           <ion-label>
             {{ picker.name }}
-            <p>{{ picker.id }}</p>
+            <p>{{ picker.externalId }}</p>
           </ion-label>
           <ion-checkbox :checked="isPickerSelected(picker.id)"/>
         </ion-item>
@@ -196,7 +196,7 @@ export default defineComponent({
         orderBy: "firstName ASC",
         filterByDate: "Y",
         distinct: "Y",
-        fieldList: ["firstName", "lastName", "partyId"]
+        fieldList: ["firstName", "lastName", "partyId", "externalId"]
       }
 
       try {
@@ -204,7 +204,8 @@ export default defineComponent({
         if (resp.status === 200 && !hasError(resp)) {
           this.pickers = resp.data.docs.map((picker) => ({
             name: picker.firstName+ ' ' +picker.lastName,
-            id: picker.partyId
+            id: picker.partyId,
+            externalId: picker.externalId
           }))
         } else {
           throw resp.data


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #183 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Helps in identifying the picker easily when pickers are sharing the same name.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

Before:

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/bf8e46c9-20d3-49b7-b12e-187b211fa1d1)


After:

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/7c395339-79b4-4329-b4d8-cc2000143b77)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)