### PR TITLE
Fixed: issue of same package being added when clicking add box button multiple times(#198)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -258,8 +258,7 @@ const actions: ActionTree<OrderState, RootState> = {
             picklistBinId: orderItem.picklistBinId,
             items: order.doclist.docs,
             shipmentMethodTypeId: orderItem.shipmentMethodTypeId,
-            shipmentMethodTypeDesc: orderItem.shipmentMethodTypeDesc,
-            isAddingBox: false
+            shipmentMethodTypeDesc: orderItem.shipmentMethodTypeDesc
           }
         })
       } else {

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -259,6 +259,7 @@ const actions: ActionTree<OrderState, RootState> = {
             items: order.doclist.docs,
             shipmentMethodTypeId: orderItem.shipmentMethodTypeId,
             shipmentMethodTypeDesc: orderItem.shipmentMethodTypeDesc,
+            isAddingBox: false
           }
         })
       } else {

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -67,7 +67,7 @@
             </div>
             <!-- TODO: implement functionality to change the type of box -->
             <div class="box-type desktop-only"  v-else-if="order.shipmentPackages">
-              <ion-button @click="addShipmentBox(order)" fill="outline" shape="round" size="small"><ion-icon :icon="addOutline" />{{ $t("Add Box") }}</ion-button>
+              <ion-button :disabled="order.isAddingBox" @click="addShipmentBox(order)" fill="outline" shape="round" size="small"><ion-icon :icon="addOutline" />{{ $t("Add Box") }}</ion-button>
               <ion-chip v-for="shipmentPackage in order.shipmentPackages" :key="shipmentPackage.shipmentId">{{ getShipmentPackageNameAndType(shipmentPackage, order) }}</ion-chip>
             </div>
 
@@ -711,11 +711,7 @@ export default defineComponent({
       return defaultBoxType;
     },
     async addShipmentBox(order: any) {
-      if(order.isAddingBox) {
-        return;
-      }
-
-      // changing the flag to know that process to add the box is in process
+      // changing the flag to know that process to add the box is in-progress
       order.isAddingBox = true;
 
       const { carrierPartyId, shipmentMethodTypeId } = await this.fetchShipmentRouteSegmentInformation(order.shipmentIds)

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -711,6 +711,13 @@ export default defineComponent({
       return defaultBoxType;
     },
     async addShipmentBox(order: any) {
+      if(order.isAddingBox) {
+        return;
+      }
+
+      // changing the flag to know that process to add the box is in process
+      order.isAddingBox = true;
+
       const { carrierPartyId, shipmentMethodTypeId } = await this.fetchShipmentRouteSegmentInformation(order.shipmentIds)
       
       if(!this.defaultShipmentBoxType) {
@@ -739,6 +746,8 @@ export default defineComponent({
         showToast(translate('Failed to add box'))
         logger.error('Failed to add box', err)
       }
+
+      order.isAddingBox = false;  // setting the value again to default once the box adding process is completed
     },
     getShipmentPackageNameAndType(shipmentPackage: any, order: any) {
       // TODO

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -67,7 +67,7 @@
             </div>
             <!-- TODO: implement functionality to change the type of box -->
             <div class="box-type desktop-only"  v-else-if="order.shipmentPackages">
-              <ion-button :disabled="order.isAddingBox" @click="addShipmentBox(order)" fill="outline" shape="round" size="small"><ion-icon :icon="addOutline" />{{ $t("Add Box") }}</ion-button>
+              <ion-button :disabled="orderBoxes.includes(order.orderId)" @click="addShipmentBox(order)" fill="outline" shape="round" size="small"><ion-icon :icon="addOutline" />{{ $t("Add Box") }}</ion-button>
               <ion-chip v-for="shipmentPackage in order.shipmentPackages" :key="shipmentPackage.shipmentId">{{ getShipmentPackageNameAndType(shipmentPackage, order) }}</ion-chip>
             </div>
 
@@ -247,13 +247,14 @@ export default defineComponent({
       rejectReasons: 'util/getRejectReasons',
       currentEComStore: 'user/getCurrentEComStore',
       userPreference: 'user/getUserPreference'
-    })
+    }),
   },
   data() {
     return {
       picklists: [] as any,
       defaultShipmentBoxType: '',
       itemsIssueSegmentSelected: [] as any,
+      orderBoxes: [] as any
     }
   },
   methods: {
@@ -711,8 +712,7 @@ export default defineComponent({
       return defaultBoxType;
     },
     async addShipmentBox(order: any) {
-      // changing the flag to know that process to add the box is in-progress
-      order.isAddingBox = true;
+      this.orderBoxes.push(order.orderId)
 
       const { carrierPartyId, shipmentMethodTypeId } = await this.fetchShipmentRouteSegmentInformation(order.shipmentIds)
       
@@ -742,8 +742,7 @@ export default defineComponent({
         showToast(translate('Failed to add box'))
         logger.error('Failed to add box', err)
       }
-
-      order.isAddingBox = false;  // setting the value again to default once the box adding process is completed
+      this.orderBoxes.splice(this.orderBoxes.indexOf(order.orderId), 1)
     },
     getShipmentPackageNameAndType(shipmentPackage: any, order: any) {
       // TODO


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #198 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In the current scenario, when a user clicks the add box button multiple times, multiple boxes gets added with the same package name, resulting in wrong user experience. So created a flag `isAddingBox` on order level to know whether the box adding is in-process or completed and not make furthur api calls for adding the box untill the previous call is not completed.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)