### PR TITLE
Implemented: a check in findOrders actions in progress and completed that if no orders are found then do not fetch additional information

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -273,14 +273,11 @@ const actions: ActionTree<OrderState, RootState> = {
     commit(types.ORDER_INPROGRESS_QUERY_UPDATED, { ...inProgressQuery })
     commit(types.ORDER_INPROGRESS_UPDATED, {orders, total})
 
-    // If no orders then no need to fetch any additional information
-    if(!orders.length){
-      emitter.emit('dismissLoader');
-      return;
-    }
-
     // fetching the additional information like shipmentRoute, carrierParty information
-    dispatch('fetchInProgressOrdersAdditionalInformation')
+    // If no orders then no need to fetch any additional information
+    if(orders.length){      
+      dispatch('fetchInProgressOrdersAdditionalInformation');
+    }
 
     emitter.emit('dismissLoader');
     return resp;
@@ -427,16 +424,13 @@ const actions: ActionTree<OrderState, RootState> = {
 
     commit(types.ORDER_COMPLETED_QUERY_UPDATED, { ...completedOrderQuery })
     commit(types.ORDER_COMPLETED_UPDATED, {list: orders, total})
-
-    // If no orders then no need to fetch any additional information
-    if(!orders.length){
-      emitter.emit('dismissLoader');
-      return;
-    }
-
+    
     // fetching the additional information like shipmentRoute, carrierParty information
     // TODO make it async and use skelatal pattern
-    await dispatch('fetchCompletedOrdersAdditionalInformation')
+    // If no orders then no need to fetch any additional information
+    if(orders.length){
+      await dispatch('fetchCompletedOrdersAdditionalInformation');
+    }
 
     emitter.emit('dismissLoader');
     return resp;

--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -273,6 +273,12 @@ const actions: ActionTree<OrderState, RootState> = {
     commit(types.ORDER_INPROGRESS_QUERY_UPDATED, { ...inProgressQuery })
     commit(types.ORDER_INPROGRESS_UPDATED, {orders, total})
 
+    // If no orders then no need to fetch any additional information
+    if(!orders.length){
+      emitter.emit('dismissLoader');
+      return;
+    }
+
     // fetching the additional information like shipmentRoute, carrierParty information
     dispatch('fetchInProgressOrdersAdditionalInformation')
 
@@ -421,6 +427,12 @@ const actions: ActionTree<OrderState, RootState> = {
 
     commit(types.ORDER_COMPLETED_QUERY_UPDATED, { ...completedOrderQuery })
     commit(types.ORDER_COMPLETED_UPDATED, {list: orders, total})
+
+    // If no orders then no need to fetch any additional information
+    if(!orders.length){
+      emitter.emit('dismissLoader');
+      return;
+    }
 
     // fetching the additional information like shipmentRoute, carrierParty information
     // TODO make it async and use skelatal pattern


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #218

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
If check in find in progress order action and find completed order action
that if orders are not found then do not fetch additional information


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)