### PR TITLE
Implemented: Commented out the refresh button with no functionality present ath the Open Orders Page (#244)

### DIFF
--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -49,9 +49,11 @@
                   <ion-icon :icon="pricetagOutline" />
                   <ion-label>{{ orders.doclist.docs[0].orderName }}</ion-label>
                 </ion-chip>
-                <ion-button fill="clear" class="mobile-only" color="danger">
+
+                <!-- Todo: add functionality to the refresh button -->
+                <!-- <ion-button fill="clear" class="mobile-only" color="danger">
                   <ion-icon slot="icon-only" :icon="refreshCircleOutline" />
-                </ion-button>
+                </ion-button> -->
               </div>
 
               <div class="order-metadata">


### PR DESCRIPTION
### Related Issues
Closes #244

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Commented out the refresh icon button present on the Open Orders Page which has no functionality added in it. As of now it does nothing when clicked.

### Screenshots of Visual Changes before/after (If There Are Any)
Before
![Screenshot from 2023-08-14 15-26-32](https://github.com/hotwax/fulfillment-pwa/assets/69574321/cb4b99bb-3a79-4a43-9345-d737528ec77f)

After
![Screenshot from 2023-08-14 15-25-45](https://github.com/hotwax/fulfillment-pwa/assets/69574321/0b525e07-f941-42b1-a281-8367860b92e9)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)