### PR TITLE
Implemented: toast for Blocked Pop-Ups when Generating Order Documents (#254)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -238,6 +238,7 @@
   "Turn on fulfillment": "Turn on fulfillment",
   "Turn on fulfillment for ": "Turn on fulfillment for { facilityName }",
   "Turn off fulfillment for ": "Turn off fulfillment for { facilityName }",
+  "Unable to open as browser is blocking pop-ups.": "Unable to open { documentName } as browser is blocking pop-ups.",
   "Unpack": "Unpack",
   "Unpacking this order will send it back to 'In progress' and it will have to be repacked.": "Unpacking this order will send it back to 'In progress' and it will have to be repacked.",
   "Update": "Update",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -238,6 +238,7 @@
   "Turn on fulfillment": "Activar Cumplimiento",
   "Turn on fulfillment for ": "Activar cumplimiento para {facilityName}",
   "Turn off fulfillment for ": "Desactivar cumplimiento para {facilityName}",
+  "Unable to open as browser is blocking pop-ups.": "Unable to open { documentName } as browser is blocking pop-ups.",
   "Unpack": "Desempacar",
   "Unpacking this order will send it back to 'In progress' and it will have to be repacked.": "Desempacar este pedido lo enviará de vuelta a 'En curso' y tendrá que ser vuelto a empacar.",
   "Update": "Update",

--- a/src/services/OrderService.ts
+++ b/src/services/OrderService.ts
@@ -3,6 +3,7 @@ import { translate } from '@/i18n';
 import logger from '@/logger';
 import { showToast } from '@/utils';
 import store from '@/store';
+import { cogOutline } from 'ionicons/icons';
 
 const findOpenOrders = async (query: any): Promise<any> => {
   return api({
@@ -191,7 +192,12 @@ const printPackingSlip = async (shipmentIds: Array<string>): Promise<any> => {
     // Generate local file URL for the blob received
     const pdfUrl = window.URL.createObjectURL(resp.data);
     // Open the file in new tab
-    (window as any).open(pdfUrl, "_blank").focus();
+    try {
+      (window as any).open(pdfUrl, "_blank").focus();
+    }
+    catch {
+      showToast(translate('Unable to open as browser is blocking pop-ups.', {documentName: 'packing slip'}), { icon: cogOutline });
+    }
 
   } catch (err) {
     showToast(translate('Failed to print packing slip'))
@@ -218,7 +224,12 @@ const printShippingLabel = async (shipmentIds: Array<string>): Promise<any> => {
     // Generate local file URL for the blob received
     const pdfUrl = window.URL.createObjectURL(resp.data);
     // Open the file in new tab
-    (window as any).open(pdfUrl, "_blank").focus();
+    try {
+      (window as any).open(pdfUrl, "_blank").focus();
+    }
+    catch {
+      showToast(translate('Unable to open as browser is blocking pop-ups.', {documentName: 'shipping label'}), { icon: cogOutline });
+    }
 
   } catch (err) {
     showToast(translate('Failed to print shipping label'))
@@ -246,7 +257,12 @@ const printShippingLabelAndPackingSlip = async (shipmentIds: Array<string>): Pro
     // Generate local file URL for the blob received
     const pdfUrl = window.URL.createObjectURL(resp.data);
     // Open the file in new tab
-    (window as any).open(pdfUrl, "_blank").focus();
+    try {
+      (window as any).open(pdfUrl, "_blank").focus();
+    }
+    catch {
+      showToast(translate('Unable to open as browser is blocking pop-ups.', {documentName: 'shipping label and packing slip'}), { icon: cogOutline });
+    }
 
   } catch (err) {
     showToast(translate('Failed to print shipping label and packing slip'))
@@ -272,8 +288,12 @@ const printPicklist = async (picklistId: string): Promise<any> => {
     // Generate local file URL for the blob received
     const pdfUrl = window.URL.createObjectURL(resp.data);
     // Open the file in new tab
-    (window as any).open(pdfUrl, "_blank").focus();
-
+    try {
+      (window as any).open(pdfUrl, "_blank").focus();
+    }
+    catch {
+      showToast(translate('Unable to open as browser is blocking pop-ups.', {documentName: 'picklist'}), { icon: cogOutline });
+    }
   } catch (err) {
     showToast(translate('Failed to print picklist'))
     logger.error("Failed to print picklist", err)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,13 +14,14 @@ const hasError = (response: any) => {
   return typeof response.data != "object" || !!response.data._ERROR_MESSAGE_ || !!response.data._ERROR_MESSAGE_LIST_ || !!response.data.error;
 }
 
-const showToast = async (message: string, canDismiss?: boolean, manualDismiss?: boolean, position?: string) => {
+const showToast = async (message: string, options?: any) => {  
   const config = {
-    message,
-    position: position ? position : 'bottom',
-  } as any
+     message,
+     ...options
+  } as any;
 
-  if (canDismiss) {
+  if(!options.position) config.position = 'bottom';
+  if(options.canDismiss){
     config.buttons = [
       {
         text: translate('Dismiss'),
@@ -28,14 +29,13 @@ const showToast = async (message: string, canDismiss?: boolean, manualDismiss?: 
       },
     ]
   }
-
-  if (!manualDismiss) {
-    config.duration = 3000
+  if (!options.manualDismiss) {
+    config.duration = 3000;
   }
 
   const toast = await toastController.create(config)
   // present toast if manual dismiss is not needed
-  return !manualDismiss ? toast.present() : toast
+  return !options.manualDismiss ? toast.present() : toast
 }
 
 const handleDateTimeInput = (dateTimeValue: any) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -20,7 +20,9 @@ const showToast = async (message: string, options?: any) => {
     ...options
   } as any;
 
-  if (!options.position) config.position = 'bottom';
+  if (!options.position) {
+    config.position = 'bottom';
+  }
   if (options.canDismiss) {
     config.buttons = [
       {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,12 +16,12 @@ const hasError = (response: any) => {
 
 const showToast = async (message: string, options?: any) => {  
   const config = {
-     message,
-     ...options
+    message,
+    ...options
   } as any;
 
-  if(!options.position) config.position = 'bottom';
-  if(options.canDismiss){
+  if (!options.position) config.position = 'bottom';
+  if (options.canDismiss) {
     config.buttons = [
       {
         text: translate('Dismiss'),

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -435,7 +435,7 @@ export default defineComponent({
                 // the associated ids, currently passing the associated shipmentId
                 if (data.length) {
                   // additional parameters for dismiss button and manual dismiss ability
-                toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
+                  toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
                   toast.present()
                   if (data.includes('printPackingSlip') && data.includes('printShippingLabel')) {
                     await OrderService.printShippingLabelAndPackingSlip(shipmentIds)

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -347,7 +347,7 @@ export default defineComponent({
 
                 if (data.length) {
                   // additional parameters for dismiss button and manual dismiss ability
-                  toast = await showToast(translate('Order packed successfully. Document generation in process'), true, true)
+                  toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
                   toast.present()
 
                   if (data.includes('printPackingSlip') && data.includes('printShippingLabel')) {
@@ -435,7 +435,7 @@ export default defineComponent({
                 // the associated ids, currently passing the associated shipmentId
                 if (data.length) {
                   // additional parameters for dismiss button and manual dismiss ability
-                  toast = await showToast(translate('Order packed successfully. Document generation in process'), true, true)
+                toast = await showToast(translate('Order packed successfully. Document generation in process'), { canDismiss: true, manualDismiss: true })
                   toast.present()
                   if (data.includes('printPackingSlip') && data.includes('printShippingLabel')) {
                     await OrderService.printShippingLabelAndPackingSlip(shipmentIds)


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #254

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Implemented the following - 
- handled error while redirecting to new tab ( Now showing toast to user that browser pop up is blocked so unable to open the document )
- changes in showToast function of utils so that it can be used with other options also
- changes in progress view as showtoast function changed ( if there are more args in showToast now passing them as object with options) 

### Steps to verify - 
- Show toast when unable to open order documents when browser pop ups are blocked.
- Show toast which can be dismissed by the user when packing in progress order.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-08-29 16-43-53](https://github.com/hotwax/fulfillment-pwa/assets/67117461/6cea429e-9739-4d5e-ab8e-fd4412ffaf19)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)