### PR TITLE
Implemented: support to show product QOH on order card(#182)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,6 +118,7 @@
   "Map all fields": "Map all fields",
   "Mapping name": "Mapping name",
   "Mismatch": "Mismatch",
+  "No data available!": "No data available!",
   "No data Found.": "No data Found.",
   "No new file upload. Please try again": "No new file upload. Please try again",
   "No reason": "No reason",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -118,6 +118,7 @@
   "Map all fields": "Map all fields",
   "Mapping name": "Mapping name",
   "Mismatch": "Inconsistencia",
+  "No data available!": "No data available!",
   "No data Found.": "No data Found.",
   "No new file upload. Please try again": "No se cargó ningún archivo nuevo. Por favor, inténtalo nuevamente.",
   "No reason": "Sin motivo",

--- a/src/services/StockService.ts
+++ b/src/services/StockService.ts
@@ -1,6 +1,6 @@
 import { api } from '@/adapter';
 
-const getInventoryAvailableByFacility = async (query: any): Promise <any>  => {
+const getInventoryAvailableByFacility = async (query: any): Promise <any> => {
   return api({
     url: "service/getInventoryAvailableByFacility", 
     method: "post",

--- a/src/services/StockService.ts
+++ b/src/services/StockService.ts
@@ -1,0 +1,13 @@
+import { api } from '@/adapter';
+
+const getInventoryAvailableByFacility = async (query: any): Promise <any>  => {
+  return api({
+    url: "service/getInventoryAvailableByFacility", 
+    method: "post",
+    data: query
+  });
+}
+
+export const StockService = {
+  getInventoryAvailableByFacility
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,6 +8,7 @@ import userModule from './modules/user';
 import productModule from "./modules/product"
 import orderModule from "./modules/order"
 import utilModule from "./modules/util"
+import stockModule from "./modules/stock"
 import { setPermissions } from '@/authorization'
 
 
@@ -36,7 +37,8 @@ const store = createStore<RootState>({
         'user': userModule,
         'product': productModule,
         'order': orderModule,
-        'util': utilModule
+        'util': utilModule,
+        'stock': stockModule
     },
 })
 

--- a/src/store/modules/stock/StockState.ts
+++ b/src/store/modules/stock/StockState.ts
@@ -1,0 +1,3 @@
+export default interface StockState {
+  products: any;
+}

--- a/src/store/modules/stock/UtilState.ts
+++ b/src/store/modules/stock/UtilState.ts
@@ -1,0 +1,6 @@
+export default interface UtilState {
+  rejectReasons: [];
+  partyNames: any;
+  shipmentMethodTypeDesc: any;
+  shipmentBoxTypeDesc: any;
+}

--- a/src/store/modules/stock/UtilState.ts
+++ b/src/store/modules/stock/UtilState.ts
@@ -1,6 +1,0 @@
-export default interface UtilState {
-  rejectReasons: [];
-  partyNames: any;
-  shipmentMethodTypeDesc: any;
-  shipmentBoxTypeDesc: any;
-}

--- a/src/store/modules/stock/actions.ts
+++ b/src/store/modules/stock/actions.ts
@@ -5,6 +5,8 @@ import StockState from './StockState'
 import * as types from './mutation-types'
 import { hasError } from '@/adapter'
 import logger from '@/logger'
+import { showToast } from '@/utils'
+import { translate } from '@/i18n'
 
 const actions: ActionTree<StockState, RootState> = {
   async fetchStock({ commit }, { productId }) {
@@ -17,33 +19,15 @@ const actions: ActionTree<StockState, RootState> = {
 
       const resp: any = await StockService.getInventoryAvailableByFacility(payload);
 
-      if (resp.status === 200 && !hasError(resp)) {
+      if (!hasError(resp)) {
         commit(types.STOCK_ADD_PRODUCT, { productId: payload.productId, stock: resp.data })
+      } else {
+        throw resp.data;
       }
     } catch(err) {
       logger.error(err)
+      showToast(translate('No data available!'))
     }
-  },
-
-  /**
-  * Add stocks of list of products
-  */
-  async addProducts({ dispatch, state }, { productIds }) {
-    const cachedProductIds = Object.keys(state.products);
-    const productIdFilter= productIds.reduce((filter: Array<string>, productId: any) => {
-      // If product not available in cached products then only fetch the stock for that product
-      if (productId && !cachedProductIds.includes(productId)) {
-        filter.push(productId)
-      }
-
-      return filter
-    }, []);
-
-    // If there are no products skip the API call
-    if (!productIdFilter.length) return;
-
-    dispatch('fetchStock', { productIds: productIdFilter })
   }
-
 }
 export default actions;

--- a/src/store/modules/stock/actions.ts
+++ b/src/store/modules/stock/actions.ts
@@ -1,0 +1,49 @@
+import { StockService } from '@/services/StockService'
+import { ActionTree } from 'vuex'
+import RootState from '@/store/RootState'
+import StockState from './StockState'
+import * as types from './mutation-types'
+import { hasError } from '@/adapter'
+import logger from '@/logger'
+
+const actions: ActionTree<StockState, RootState> = {
+  async fetchStock({ commit }, { productId }) {
+
+    try {
+      const payload = {
+        productId,
+        facilityId: this.state.user.currentFacility.facilityId
+      }
+
+      const resp: any = await StockService.getInventoryAvailableByFacility(payload);
+
+      if (resp.status === 200 && !hasError(resp)) {
+        commit(types.STOCK_ADD_PRODUCT, { productId: payload.productId, stock: resp.data })
+      }
+    } catch(err) {
+      logger.error(err)
+    }
+  },
+
+  /**
+  * Add stocks of list of products
+  */
+  async addProducts({ dispatch, state }, { productIds }) {
+    const cachedProductIds = Object.keys(state.products);
+    const productIdFilter= productIds.reduce((filter: Array<string>, productId: any) => {
+      // If product not available in cached products then only fetch the stock for that product
+      if (productId && !cachedProductIds.includes(productId)) {
+        filter.push(productId)
+      }
+
+      return filter
+    }, []);
+
+    // If there are no products skip the API call
+    if (!productIdFilter.length) return;
+
+    dispatch('fetchStock', { productIds: productIdFilter })
+  }
+
+}
+export default actions;

--- a/src/store/modules/stock/getters.ts
+++ b/src/store/modules/stock/getters.ts
@@ -1,0 +1,10 @@
+import { GetterTree } from 'vuex'
+import StockState from './StockState'
+import RootState from '../../RootState'
+
+const getters: GetterTree <StockState, RootState> = {
+  getProductStock: (state) => (productId: string) => {
+    return state.products[productId] ? state.products[productId] : 0
+  }
+}
+export default getters;

--- a/src/store/modules/stock/getters.ts
+++ b/src/store/modules/stock/getters.ts
@@ -4,7 +4,7 @@ import RootState from '../../RootState'
 
 const getters: GetterTree <StockState, RootState> = {
   getProductStock: (state) => (productId: string) => {
-    return state.products[productId] ? state.products[productId] : 0
+    return state.products[productId] ? state.products[productId] : {}
   }
 }
 export default getters;

--- a/src/store/modules/stock/index.ts
+++ b/src/store/modules/stock/index.ts
@@ -1,0 +1,19 @@
+
+import actions from './actions'
+import getters from './getters'
+import mutations from './mutations'
+import { Module } from 'vuex'
+import StockState from './StockState'
+import RootState from '../../RootState'
+
+const stockModule: Module<StockState, RootState> = {
+  namespaced: true,
+  state: {
+    products: {}
+  },
+  getters,
+  actions,
+  mutations,
+}
+
+export default stockModule;

--- a/src/store/modules/stock/mutation-types.ts
+++ b/src/store/modules/stock/mutation-types.ts
@@ -1,0 +1,3 @@
+export const SN_STOCK = 'stock'
+export const STOCK_ADD_PRODUCT = SN_STOCK + '/ADD_PRODUCT'
+export const STOCK_ADD_PRODUCTS = SN_STOCK + '/ADD_PRODUCTS'

--- a/src/store/modules/stock/mutation-types.ts
+++ b/src/store/modules/stock/mutation-types.ts
@@ -1,3 +1,2 @@
 export const SN_STOCK = 'stock'
 export const STOCK_ADD_PRODUCT = SN_STOCK + '/ADD_PRODUCT'
-export const STOCK_ADD_PRODUCTS = SN_STOCK + '/ADD_PRODUCTS'

--- a/src/store/modules/stock/mutations.ts
+++ b/src/store/modules/stock/mutations.ts
@@ -1,0 +1,15 @@
+import { MutationTree } from 'vuex'
+import StockState from './StockState'
+import * as types from './mutation-types'
+
+const mutations: MutationTree <StockState> = {
+  [types.STOCK_ADD_PRODUCT] (state, payload) {
+    state.products[payload.productId] = payload.stock
+  },
+  [types.STOCK_ADD_PRODUCTS] (state, payload) {
+    payload.products.forEach((product: any) => {
+      state.products[product.productId] = product.atp
+    });
+  }
+}
+export default mutations;

--- a/src/store/modules/stock/mutations.ts
+++ b/src/store/modules/stock/mutations.ts
@@ -5,11 +5,6 @@ import * as types from './mutation-types'
 const mutations: MutationTree <StockState> = {
   [types.STOCK_ADD_PRODUCT] (state, payload) {
     state.products[payload.productId] = payload.stock
-  },
-  [types.STOCK_ADD_PRODUCTS] (state, payload) {
-    payload.products.forEach((product: any) => {
-      state.products[product.productId] = product.atp
-    });
   }
 }
 export default mutations;

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -80,6 +80,14 @@
                   </ion-label>
                 </ion-item>
               </div>
+
+              <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
+              <div class="product-metadata">
+                <ion-note v-if="getProductStock(item.productId).quantityOnHandTotal">{{ getProductStock(item.productId).quantityOnHandTotal }} {{ $t('pieces in stock') }}</ion-note>
+                <ion-button fill="clear" v-else size="small" @click="fetchProductStock(item.productId)">
+                  <ion-icon color="medium" slot="icon-only" :icon="cubeOutline"/>
+                </ion-button>
+              </div>
             </div>
 
             <!-- TODO: implement functionality to mobile view -->
@@ -147,6 +155,7 @@ import {
   IonItem,
   IonLabel,
   IonMenuButton,
+  IonNote,
   IonPage,
   IonSearchbar,
   IonSpinner,
@@ -158,7 +167,7 @@ import {
   modalController
 } from '@ionic/vue';
 import { defineComponent } from 'vue';
-import { printOutline, downloadOutline, pricetagOutline, ellipsisVerticalOutline, checkmarkDoneOutline, optionsOutline } from 'ionicons/icons'
+import { cubeOutline, printOutline, downloadOutline, pricetagOutline, ellipsisVerticalOutline, checkmarkDoneOutline, optionsOutline } from 'ionicons/icons'
 import Popover from '@/views/ShippingPopover.vue'
 import { useRouter } from 'vue-router';
 import { mapGetters, useStore } from 'vuex'
@@ -194,6 +203,7 @@ export default defineComponent({
     IonItem,
     IonLabel,
     IonMenuButton,
+    IonNote,
     IonPage,
     IonSearchbar,
     IonSpinner,
@@ -216,7 +226,8 @@ export default defineComponent({
       currentFacility: 'user/getCurrentFacility',
       currentEComStore: 'user/getCurrentEComStore',
       getPartyName: 'util/getPartyName',
-      getShipmentMethodDesc: 'util/getShipmentMethodDesc'
+      getShipmentMethodDesc: 'util/getShipmentMethodDesc',
+      getProductStock: 'stock/getProductStock'
     })
   },
   async mounted() {
@@ -595,6 +606,9 @@ export default defineComponent({
         }
       });
       return shippingLabelErrorModal.present();
+    },
+    fetchProductStock(productId: string) {
+      this.store.dispatch('stock/fetchStock', { productId })
     }
   },
   setup() {
@@ -605,6 +619,7 @@ export default defineComponent({
       Actions,
       copyToClipboard,
       checkmarkDoneOutline,
+      cubeOutline,
       downloadOutline,
       ellipsisVerticalOutline,
       formatUtcDate,

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -138,6 +138,12 @@
                 </div>
               </div>
 
+              <div class="product-metadata">
+                <ion-note v-if="getProductStock(item.productId).quantityOnHandTotal">{{ getProductStock(item.productId).quantityOnHandTotal }} {{ $t('pieces in stock') }}</ion-note>
+                <ion-button fill="clear" v-else size="small" @click="fetchProductStock(item.productId)">
+                  <ion-icon color="medium" slot="icon-only" :icon="cubeOutline"/>
+                </ion-button>
+              </div>
             </div>
 
             <div class="mobile-only">
@@ -206,6 +212,7 @@ import {
   IonInfiniteScrollContent,
   IonLabel,
   IonMenuButton,
+  IonNote,
   IonPage,
   IonRow,
   IonRadio,
@@ -228,6 +235,7 @@ import { defineComponent } from 'vue';
 import {
   addOutline,
   checkmarkDoneOutline,
+  cubeOutline,
   ellipsisVerticalOutline,
   pencilOutline,
   pricetagOutline,
@@ -270,6 +278,7 @@ export default defineComponent({
     IonInfiniteScrollContent,
     IonLabel,
     IonMenuButton,
+    IonNote,
     IonPage,
     IonRow,
     IonRadio,
@@ -294,7 +303,8 @@ export default defineComponent({
       rejectReasons: 'util/getRejectReasons',
       currentEComStore: 'user/getCurrentEComStore',
       userPreference: 'user/getUserPreference',
-      boxTypeDesc: 'util/getShipmentBoxDesc'
+      boxTypeDesc: 'util/getShipmentBoxDesc',
+      getProductStock: 'stock/getProductStock'
     }),
   },
   data() {
@@ -934,6 +944,9 @@ export default defineComponent({
 
       return editPickersModal.present();
     },
+    fetchProductStock(productId: string) {
+      this.store.dispatch('stock/fetchStock', { productId })
+    }
   },
   async mounted () {
     this.store.dispatch('util/fetchRejectReasons')
@@ -950,6 +963,7 @@ export default defineComponent({
     return {
       Actions,
       copyToClipboard,
+      cubeOutline,
       addOutline,
       printOutline,
       pencilOutline,

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -73,6 +73,14 @@
                     </ion-label>
                   </ion-item>
                 </div>
+
+                <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
+                <div class="product-metadata">
+                  <ion-note v-if="getProductStock(order.productId).quantityOnHandTotal">{{ getProductStock(order.productId).quantityOnHandTotal }} {{ $t('pieces in stock') }}</ion-note>
+                  <ion-button fill="clear" v-else size="small" @click="fetchProductStock(order.productId)">
+                    <ion-icon color="medium" slot="icon-only" :icon="cubeOutline"/>
+                  </ion-button>
+                </div>
               </div>
             </div>
 
@@ -118,6 +126,7 @@ import {
   IonInfiniteScrollContent,
   IonItem, 
   IonMenuButton,
+  IonNote,
   IonPage, 
   IonSearchbar, 
   IonThumbnail, 
@@ -128,7 +137,7 @@ import {
   popoverController
 } from '@ionic/vue';
 import { defineComponent } from 'vue';
-import { optionsOutline, pricetagOutline, printOutline,} from 'ionicons/icons';
+import { cubeOutline, optionsOutline, pricetagOutline, printOutline,} from 'ionicons/icons';
 import AssignPickerModal from '@/views/AssignPickerModal.vue';
 import { mapGetters, useStore } from 'vuex';
 import { ShopifyImg } from '@hotwax/dxp-components';
@@ -163,6 +172,7 @@ export default defineComponent({
     IonInfiniteScrollContent,
     IonItem,
     IonMenuButton,
+    IonNote,
     IonPage,
     IonSearchbar,
     IonThumbnail,
@@ -176,7 +186,8 @@ export default defineComponent({
       openOrders: 'order/getOpenOrders',
       getProduct: 'product/getProduct',
       currentEComStore: 'user/getCurrentEComStore',
-      getShipmentMethodDesc: 'util/getShipmentMethodDesc'
+      getShipmentMethodDesc: 'util/getShipmentMethodDesc',
+      getProductStock: 'stock/getProductStock'
     })
   },
   data () {
@@ -328,6 +339,9 @@ export default defineComponent({
         event: ev
       });
       return popover.present();
+    },
+    fetchProductStock(productId: string) {
+      this.store.dispatch('stock/fetchStock', { productId })
     }
   },
   async mounted () {
@@ -343,6 +357,7 @@ export default defineComponent({
 
     return{
       Actions,
+      cubeOutline,
       formatUtcDate,
       getFeature,
       hasPermission,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #182 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

- Go to any of the open, inProgress or completed page
- Click on cube icon to fetch the stock
- Verify that the stock is visible and if not fetched due to an error in api then toast is displayed.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

After:

When stock for product is not yet fetched:

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/8f67c0a6-c051-4462-b0d6-c846610fe9be)


When stock for a product is available:

![image](https://github.com/hotwax/fulfillment-pwa/assets/41404838/ff10930b-6c6c-432a-824c-4ac39e25ffaa)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)