### PR TITLE
Fixed: issue of user unable to logout from the app

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -125,8 +125,13 @@ const actions: ActionTree<UserState, RootState> = {
     if(!payload?.isUserUnauthorised) {
       let resp = await logout();
 
-      // Added logic to remove the `//` from the resp as in case of get request we are having the extra characters and in case of post we are having 403
-      resp = JSON.parse(resp.startsWith('//') ? resp.replace('//', '') : resp)
+      // wrapping the parsing logic in try catch as in some case the logout api makes redirection, and then we are unable to parse the resp and thus the logout process halts
+      try {
+        // Added logic to remove the `//` from the resp as in case of get request we are having the extra characters and in case of post we are having 403
+        resp = JSON.parse(resp.startsWith('//') ? resp.replace('//', '') : resp)
+      } catch(err) {
+        logger.error('Error parsing data', err)
+      }
 
       if(resp.logoutAuthType == 'SAML2SSO') {
         redirectionUrl = resp.logoutUrl


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Currently, in some cases the logout api makes an internal redirection, and thus we are unable to parse the resp which in turn halts the logout process, so fixed this case by wrapping the parsing logic of resp in try-catch block, so if in any case parsing fails the user still gets logged out of the app.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)