### PR TITLE
Improved: dateTime format for facilityOrderCount inputFields (#241)

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -319,7 +319,7 @@ export default defineComponent({
           "entityName": "FacilityOrderCount",
           "inputFields": {
             "facilityId": this.currentFacility.facilityId,
-            "entryDate": DateTime.now().toMillis(),
+            "entryDate": DateTime.now().toFormat('yyyy-MM-dd'),
           },
           "viewSize": 1,
           "fieldList": ["entryDate", "lastOrderCount"],


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated the DateTime format to send the date in 'yyyy-mm-dd' format for facilityOrderCount api on settings page

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)