### PR TITLE
Improved: code to have support for storing stock by facility(#313)

### DIFF
--- a/src/store/modules/order/actions.ts
+++ b/src/store/modules/order/actions.ts
@@ -547,7 +547,6 @@ const actions: ActionTree<OrderState, RootState> = {
       groupBy: 'shipGroupSeqId',
       filters: {
         '-shipGroupSeqId': { value: order.items[0].shipGroupSeqId },
-        '-shipmentMethodTypeId': { value: 'STOREPICKUP' },
         orderId: { value: order.orderId }
       },
       docType: 'ORDER'
@@ -603,7 +602,6 @@ const actions: ActionTree<OrderState, RootState> = {
       groupBy: 'shipGroupSeqId',
       filters: {
         'shipGroupSeqId': { value: shipGroupSeqIds },
-        '-shipmentMethodTypeId': { value: 'STOREPICKUP' },
         '-fulfillmentStatus': { value: ['Rejected', 'Cancelled'] },
         orderId: { value: orderId }
       }

--- a/src/store/modules/stock/actions.ts
+++ b/src/store/modules/stock/actions.ts
@@ -9,18 +9,19 @@ import { showToast } from '@/utils'
 import { translate } from '@hotwax/dxp-components'
 
 const actions: ActionTree<StockState, RootState> = {
-  async fetchStock({ commit }, { productId }) {
+  async fetchStock({ commit }, { productId, facilityId = '' }) {
+    const id = facilityId ? facilityId : this.state.user.currentFacility.facilityId
 
     try {
       const payload = {
         productId,
-        facilityId: this.state.user.currentFacility.facilityId
+        facilityId: id
       }
 
       const resp: any = await StockService.getInventoryAvailableByFacility(payload);
 
       if (!hasError(resp)) {
-        commit(types.STOCK_ADD_PRODUCT, { productId: payload.productId, stock: resp.data })
+        commit(types.STOCK_ADD_PRODUCT, { productId: payload.productId, facilityId: id, stock: resp.data })
       } else {
         throw resp.data;
       }

--- a/src/store/modules/stock/getters.ts
+++ b/src/store/modules/stock/getters.ts
@@ -3,8 +3,10 @@ import StockState from './StockState'
 import RootState from '../../RootState'
 
 const getters: GetterTree <StockState, RootState> = {
-  getProductStock: (state) => (productId: string) => {
-    return state.products[productId] ? state.products[productId] : {}
+  getProductStock: (state, getters, RootState) => (productId: any, facilityId?: any) => {
+    const id = facilityId ? facilityId : RootState.user.currentFacility.facilityId
+
+    return state.products[productId] ? state.products[productId][id] ? state.products[productId][id] : {} : {}
   }
 }
 export default getters;

--- a/src/store/modules/stock/mutations.ts
+++ b/src/store/modules/stock/mutations.ts
@@ -4,7 +4,13 @@ import * as types from './mutation-types'
 
 const mutations: MutationTree <StockState> = {
   [types.STOCK_ADD_PRODUCT] (state, payload) {
-    state.products[payload.productId] = payload.stock
+    if(state.products[payload.productId]) {
+      state.products[payload.productId][payload.facilityId] = payload.stock
+    } else {
+      state.products[payload.productId] = {
+        [payload.facilityId]: payload.stock
+      }
+    }
   }
 }
 export default mutations;

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -195,8 +195,8 @@
 
             <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
             <div class="product-metadata">
-              <ion-note v-if="getProductStock(item.productId).quantityOnHandTotal">{{ getProductStock(item.productId).quantityOnHandTotal }} {{ translate('pieces in stock') }}</ion-note>
-              <ion-button fill="clear" v-else size="small" @click.stop="fetchProductStock(item.productId)">
+              <ion-note v-if="getProductStock(item.productId, item.facilityId).quantityOnHandTotal">{{ getProductStock(item.productId, item.facilityId).quantityOnHandTotal }} {{ translate('pieces in stock') }}</ion-note>
+              <ion-button fill="clear" v-else size="small" @click.stop="fetchProductStock(item.productId, item.facilityId)">
                 <ion-icon color="medium" slot="icon-only" :icon="cubeOutline"/>
               </ion-button>
             </div>
@@ -378,8 +378,8 @@ export default defineComponent({
       });
       return popover.present();
     },
-    fetchProductStock(productId: string) {
-      this.store.dispatch('stock/fetchStock', { productId })
+    fetchProductStock(productId: string, facilityId = '') {
+      this.store.dispatch('stock/fetchStock', { productId, facilityId })
     },
     async packOrder(order: any) {
       const confirmPackOrder = await alertController


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed code to filter the STOREPICKUP shipGroups, as we can display storePickup information as well in additional details.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
- Removed support to exclude storePickup shipGroups from additional information
- Added support to store product stock by facility in the format: `{ productId: { facility1: stock, facility2: stock } }`

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)