### PR TITLE
Fixed: case to honor params when checking for shipGroup status on details page

### DIFF
--- a/src/utils/order.ts
+++ b/src/utils/order.ts
@@ -68,7 +68,7 @@ const getOrderCategory = (order: any) => {
     const [category, parameters] = entry
     const paramKeys = Object.keys(parameters)
     // used every as to check against each filtering property
-    const isMatched = paramKeys.every((key: string) => Object.prototype.hasOwnProperty.call(order, key) || handleParameterMatching(order[key], parameters[key].value, parameters[key]['OP']))
+    const isMatched = paramKeys.every((key: string) => Object.prototype.hasOwnProperty.call(order, key) && handleParameterMatching(order[key], parameters[key].value, parameters[key]['OP']))
 
     // return the value when all params matched for an order
     if (isMatched) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
When fetching the status for related shipGroups, only the keys check is honored and not the values are honored for checking status

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Instead of ORing on keys and value checks, changed the operator to `and`.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)