### PR TITLE
Fixed: issue of duplicate records of locale entry on settings page

### DIFF
--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -141,7 +141,7 @@ const actions: ActionTree<UserState, RootState> = {
     }
 
     const authStore = useAuthStore()
-    const userStore = useAuthStore()
+    const userStore = useUserStore()
     // TODO add any other tasks if need
     commit(types.USER_END_SESSION)
     this.dispatch('order/clearOrders')


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
As we have updated the keys for locale from `en` to `en-US` etc, so when updating the env entry the old keys are also available in the localStorage thus resulting in duplicate records for languages. So added support to reset the locale records on logout.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)