### PR TITLE
Implemented: copy utility and text wrap in shippingLabelError modal (#380)

### DIFF
--- a/src/components/ShippingLabelErrorModal.vue
+++ b/src/components/ShippingLabelErrorModal.vue
@@ -7,12 +7,18 @@
         </ion-button>
       </ion-buttons>
       <ion-title>{{ translate("Shipping label error") }}</ion-title>
+      <ion-buttons slot="end">
+        <!-- Copying first message, assuming only one message will be received -->
+        <ion-button @click="copyToClipboard(shipmentLabelErrorMessages[0], 'Copied to clipboard')"> 
+          <ion-icon slot="icon-only" :icon="copyOutline" />
+        </ion-button>
+      </ion-buttons>
     </ion-toolbar>
   </ion-header>
   <ion-content>
     <ion-list lines="none">
       <ion-item v-for="message, index in shipmentLabelErrorMessages" :key="index">
-        <ion-label>{{ message }}</ion-label>
+        <ion-label class="ion-text-wrap">{{ message }}</ion-label>
       </ion-item>
       <ion-item v-if="!shipmentLabelErrorMessages.length">
         {{ translate("No shipping label error received from carrier") }}
@@ -36,9 +42,10 @@ import {
   IonList
 } from "@ionic/vue";
 import { defineComponent } from "vue";
-import { closeOutline } from "ionicons/icons";
+import { closeOutline, copyOutline } from "ionicons/icons";
 import { OrderService } from "@/services/OrderService";
 import { translate } from "@hotwax/dxp-components";
+import { copyToClipboard } from "@/utils";
 
 export default defineComponent({
   name: "ShippingLabelErrorModal",
@@ -72,6 +79,8 @@ export default defineComponent({
   setup() {
     return {
       closeOutline,
+      copyOutline,
+      copyToClipboard,
       translate
     };
   },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #380

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Implemented copy button and text wrap in shipping label error message modal.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-12-27 16-25-06](https://github.com/hotwax/fulfillment-pwa/assets/69574321/bcf1c95a-fc85-4124-9e27-ed12fa61f773)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)