### PR TITLE
Fixed: result size filter reset when completing an order issue (389)

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -343,7 +343,8 @@ export default defineComponent({
         if(!hasError(resp)) {
           showToast(translate('Order shipped successfully'))
           // TODO: handle the case of data not updated correctly
-          await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
+          const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+          await Promise.all([this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery }), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
         } else {
           throw resp.data
         }
@@ -351,7 +352,6 @@ export default defineComponent({
         logger.error('Failed to ship order', err)
         showToast(translate('Failed to ship order'))
       }
-
     },
     async bulkShipOrders() {
       const packedOrdersCount = this.completedOrders.list.filter((order: any) => {
@@ -416,7 +416,8 @@ export default defineComponent({
                     ? showToast(translate('Orders shipped successfully'))
                     : showToast(translate('out of cannot be shipped due to missing tracking codes.', { remainingOrders: trackingRequiredAndMissingCodeOrders.length, totalOrders: packedOrdersCount }))
                   // TODO: handle the case of data not updated correctly
-                  await Promise.all([this.initialiseOrderQuery(), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
+                  const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
+                  await Promise.all([this.store.dispatch('order/updateCompletedQuery', { ...completedOrdersQuery }), this.fetchShipmentMethods(), this.fetchCarrierPartyIds()]);
                 } else {
                   throw resp.data
                 }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #389

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When we complete an order, the result size filter selected by user gets reset to default. Hence fixed this issue for not allowing it to reset.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)