### PR TITLE
Implemented: Spinner in Timezone modal such that users will see that data is being fetched

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -109,6 +109,7 @@
   "Failed to update eCom inventory status": "Failed to update eCom inventory status",
   "Failed to update facility": "Failed to update facility",
   "Failed to update order": "Failed to update order",
+  "Fetching time zones": "Fetching time zones",
   "Field mapping name": "Field mapping name",
   "File downloaded successfully": "File downloaded successfully",
   "File uploaded successfully": "File uploaded successfully",

--- a/src/views/timezone-modal.vue
+++ b/src/views/timezone-modal.vue
@@ -14,10 +14,17 @@
   </ion-header>
 
   <ion-content class="ion-padding">
-    <!-- Empty state -->
-    <div class="empty-state" v-if="filteredTimeZones.length === 0">
-      <p>{{ translate("No time zone found")}}</p>
-    </div>
+    <div class="empty-state" v-if="isLoading">
+        <ion-item lines="none">
+        <ion-spinner color="secondary" name="crescent" slot="start" />
+        {{ $t("Fetching time zones") }}
+      </ion-item>
+      </div>
+
+      <!-- Empty state -->
+      <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+        <p>{{ translate("No time zone found")}}</p>
+      </div>
 
     <!-- Timezones -->
     <div v-else>
@@ -73,7 +80,8 @@ export default defineComponent({
       queryString: '',
       filteredTimeZones: [],
       timeZones: [],
-      timeZoneId: ''
+      timeZoneId: '',
+      isLoading: false
     }
   },
   computed: {
@@ -111,6 +119,7 @@ export default defineComponent({
       });
     },
     async getAvailableTimeZones() {
+      this.isLoading = true;
       UserService.getAvailableTimeZones().then((resp: any) => {
         if (resp.status === 200 && !hasError(resp) && resp.data?.length > 0) {
           this.timeZones = resp.data.filter((timeZone: any) => {
@@ -118,6 +127,8 @@ export default defineComponent({
           });
           this.findTimeZone();
         }
+        this.isLoading = false;
+
       })
     },
     selectSearchBarText(event: any) {

--- a/src/views/timezone-modal.vue
+++ b/src/views/timezone-modal.vue
@@ -128,7 +128,6 @@ export default defineComponent({
           this.findTimeZone();
         }
         this.isLoading = false;
-
       })
     },
     selectSearchBarText(event: any) {

--- a/src/views/timezone-modal.vue
+++ b/src/views/timezone-modal.vue
@@ -14,17 +14,16 @@
   </ion-header>
 
   <ion-content class="ion-padding">
+    <!-- Empty state -->
     <div class="empty-state" v-if="isLoading">
-        <ion-item lines="none">
+      <ion-item lines="none">
         <ion-spinner color="secondary" name="crescent" slot="start" />
-        {{ $t("Fetching time zones") }}
+          {{ translate("Fetching time zones") }}
       </ion-item>
-      </div>
-
-      <!-- Empty state -->
-      <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
-        <p>{{ translate("No time zone found")}}</p>
-      </div>
+    </div>
+    <div class="empty-state" v-else-if="filteredTimeZones.length === 0">
+      <p>{{ translate("No time zone found") }}</p>
+    </div>
 
     <!-- Timezones -->
     <div v-else>
@@ -61,6 +60,7 @@ import {
   IonRadio,
   IonList,
   IonSearchbar,
+  IonSpinner,
   IonTitle,
   IonToolbar,
   modalController,
@@ -169,6 +169,7 @@ export default defineComponent({
     IonRadioGroup,
     IonRadio,
     IonSearchbar,
+    IonSpinner,
     IonTitle,
     IonToolbar 
     },


### PR DESCRIPTION
…ata is being fetched

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
I have incorporated a spinner in the TimeZoneModal to provide users with a visual cue, allowing them to easily discern when data is being fetched. This not only enhances the user experience but also ensures that users can perceive the ongoing data retrieval process

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->

![image](https://github.com/hotwax/fulfillment-pwa/assets/83332530/cc2ccc0b-7059-4290-97f5-e3e79c583a04)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)