### PR TITLE
Fixed: the ion-searchbar placeholder as 'search' to 'search orders'

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -246,7 +246,7 @@
   "Saved mappings": "Saved mappings",
   "Saved Mappings": "Saved Mappings",
   "Search": "Search",
-  "Search orders":"Search orders",
+  "Search orders": "Search orders",
   "Search time zones": "Search time zones",
   "Select": "Select",
   "Select all": "Select all",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -246,6 +246,7 @@
   "Saved mappings": "Saved mappings",
   "Saved Mappings": "Saved Mappings",
   "Search": "Search",
+  "Search orders":"Search orders",
   "Search time zones": "Search time zones",
   "Select": "Select",
   "Select all": "Select all",

--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -17,7 +17,7 @@
     </ion-header>
     
     <ion-content id="view-size-selector">
-      <ion-searchbar class="better-name-here" :value="completedOrders.query.queryString" @keyup.enter="updateQueryString($event.target.value)" />
+      <ion-searchbar class="better-name-here" :value="completedOrders.query.queryString" :placeholder="translate('Search orders')" @keyup.enter="updateQueryString($event.target.value)" />
 
       <div v-if="completedOrders.total">
 

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -21,7 +21,7 @@
     </ion-header>
     
     <ion-content id="view-size-selector">
-      <ion-searchbar class="better-name-here" v-model="inProgressOrders.query.queryString" @keyup.enter="updateQueryString($event.target.value)"/>
+      <ion-searchbar class="better-name-here" :placeholder="translate('Search orders')" v-model="inProgressOrders.query.queryString" @keyup.enter="updateQueryString($event.target.value)"/>
       <div v-if="inProgressOrders.total">
         <ion-radio-group v-model="selectedPicklistId" @ionChange="updateSelectedPicklist($event.detail.value)">
           <ion-row class="filters">

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -20,7 +20,7 @@
     </ion-header>
     
     <ion-content id="view-size-selector">
-      <ion-searchbar class="better-name-here" :value="openOrders.query.queryString" @keyup.enter="updateQueryString($event.target.value)"/>
+      <ion-searchbar class="better-name-here" :value="openOrders.query.queryString" :placeholder="translate('Search orders')" @keyup.enter="updateQueryString($event.target.value)"/>
       <div v-if="openOrders.total">
         <div class="filters">
           <ion-item lines="none" v-for="method in shipmentMethods" :key="method.val">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #404 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Updated the Searchbar text label from 'Search' to 'Search orders'.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before: 
![image](https://github.com/hotwax/fulfillment-pwa/assets/83332530/376f2e43-a1a4-4664-a0cd-b00ea594f12a)

After: 
![image](https://github.com/hotwax/fulfillment-pwa/assets/83332530/f3008c33-e97e-4c24-9ea2-0d58dd268cfd)

**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)