### PR TITLE
Fixed: remove double line from the id input in create rejection reason modal

### DIFF
--- a/src/components/CreateRejectionReasonModal.vue
+++ b/src/components/CreateRejectionReasonModal.vue
@@ -16,7 +16,7 @@
         <ion-item>
           <ion-input :label="translate('Name')" @ionBlur="setEnumId($event)" v-model="formData.enumName" />
         </ion-item>
-        <ion-item ref="enumId">
+        <ion-item ref="enumId" lines="none">
           <ion-input :label="translate('ID')" v-model="formData.enumId" @ionChange="validateEnumId" @ionBlur="markEnumIdTouched" :errorText="translate('ID cannot be more than 20 characters.')" />
         </ion-item>
         <ion-item>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Removed double line from the create rejection reason modal in ID input.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-03-20 10-42-50](https://github.com/hotwax/fulfillment-pwa/assets/69574321/3f86ac21-e3b7-4678-921c-1994db9ab3e3)

After
![Screenshot from 2024-03-20 10-42-34](https://github.com/hotwax/fulfillment-pwa/assets/69574321/6aa57edd-d15a-449e-8189-b53649ccd187)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)