### PR TITLE
Fixed: check stock button coming in middle due to only 2 items in order-item div (#470)

### DIFF
--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -95,7 +95,7 @@
             </div>
 
             <!-- In completed and inprogress category we only have two items in product item while css needs 3 hence adding an empty div. -->
-            <div v-if="category !== 'in-progress'"></div>
+            <div v-else></div>
 
             <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
             <div class="product-metadata">
@@ -131,7 +131,7 @@
                 </div>
 
                 <!-- In completed and inprogress category we only have two items in product item while css needs 3 hence adding an empty div. -->
-                <div v-if="category !== 'in-progress'"></div>
+                <div v-else></div>
 
                 <div class="product-metadata" v-if="category === 'in-progress' && order.shipmentPackages && order.shipmentPackages.length">
                   <ion-button @click="openRejectReasonPopover($event, null, order, kitProducts)" color="danger" fill="outline">

--- a/src/views/OrderDetail.vue
+++ b/src/views/OrderDetail.vue
@@ -94,6 +94,9 @@
               </ion-chip>
             </div>
 
+            <!-- In completed and inprogress category we only have two items in product item while css needs 3 hence adding an empty div. -->
+            <div v-if="category !== 'in-progress'"></div>
+
             <!-- TODO: add a spinner if the api takes too long to fetch the stock -->
             <div class="product-metadata">
               <ion-note v-if="getProductStock(item.productId).quantityOnHandTotal">{{ getProductStock(item.productId).quantityOnHandTotal }} {{ translate('pieces in stock') }}</ion-note>
@@ -126,7 +129,10 @@
                     <ion-icon :icon="caretDownOutline" />
                   </ion-chip>
                 </div>
-                    
+
+                <!-- In completed and inprogress category we only have two items in product item while css needs 3 hence adding an empty div. -->
+                <div v-if="category !== 'in-progress'"></div>
+
                 <div class="product-metadata" v-if="category === 'in-progress' && order.shipmentPackages && order.shipmentPackages.length">
                   <ion-button @click="openRejectReasonPopover($event, null, order, kitProducts)" color="danger" fill="outline">
                     {{ translate('Report an issue') }}
@@ -145,6 +151,9 @@
                     <p>{{ getFeature(getProduct(item.productId).featureHierarchy, '1/COLOR/')}} {{ getFeature(getProduct(item.productId).featureHierarchy, '1/SIZE/')}}</p>
                   </ion-label>
                 </ion-item>
+
+                <!-- Order item css needs 3 child items. Hence adding an empty div. -->
+                <div></div>
 
                 <div class="product-metadata">
                   <ion-note v-if="getProductStock(item.productId).quantityOnHandTotal">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #470

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed check stock showing in the middle of the order item.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-03-21 15-01-07](https://github.com/hotwax/fulfillment-pwa/assets/69574321/8f25ef69-fef1-45df-b872-9a81311657f9)




After
![Screenshot from 2024-03-21 15-00-44](https://github.com/hotwax/fulfillment-pwa/assets/69574321/f8eb5dae-4160-4b55-a0b0-7aeed489c54c)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)