### PR TITLE
Fixed: toast remains active once saving rejection reasons order (#466)

### DIFF
--- a/src/views/RejectionReasons.vue
+++ b/src/views/RejectionReasons.vue
@@ -207,6 +207,7 @@ export default defineComponent({
           buttons: [{
             text: translate('Save'),
             handler: () => {
+              this.toast = null
               this.saveReasonsOrder()
             }
           }],


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #466

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed - 
- Toast not showing up again on reordering reasons after saving once.
- Alert coming even after saving toast on changing route.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)