### PR TITLE
Fixed: fav icon overlapping the last reason in rejection reasons page (#487)

### DIFF
--- a/src/views/RejectionReasons.vue
+++ b/src/views/RejectionReasons.vue
@@ -263,4 +263,8 @@ export default defineComponent({
 .list-item ion-item {
   width: 100%;
 }
+
+ion-content {
+  --padding-bottom: 80px;
+}
 </style>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #487

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed fav icon overlapping the last reason in rejection reasons page

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before 
![Screenshot from 2024-03-22 15-43-10](https://github.com/hotwax/fulfillment-pwa/assets/69574321/ae3228ab-fd09-40bb-b65f-80afdb4b4cbc)

After
![Screenshot from 2024-03-22 15-43-02](https://github.com/hotwax/fulfillment-pwa/assets/69574321/13ea82a9-d39b-41bc-bf66-355cd79a6412)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)