### PR TITLE
Fixed: infinite scroll issue when used with searchbar(dxp-289) 

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -156,7 +156,7 @@
               </div>
             </div>
           </ion-card>
-          <ion-infinite-scroll @ionInfinite="loadMoreCompletedOrders($event)" threshold="100px" :disabled="!isCompletedOrderScrollable()">
+          <ion-infinite-scroll @ionInfinite="loadMoreCompletedOrders($event)" threshold="100px" :disabled="!isCompletedOrderScrollable()" :key="completedOrders.query.queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -218,7 +218,7 @@
               </div>
             </div>
           </ion-card>
-          <ion-infinite-scroll @ionInfinite="loadMoreInProgressOrders($event)" threshold="100px" :disabled="!isInProgressOrderScrollable()">
+          <ion-infinite-scroll @ionInfinite="loadMoreInProgressOrders($event)" threshold="100px" :disabled="!isInProgressOrderScrollable()" :key="inProgressOrders.query.queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -123,7 +123,7 @@
             </div> -->
           </ion-card>
 
-          <ion-infinite-scroll @ionInfinite="loadMoreOpenOrders($event)" threshold="100px" :disabled="!isOpenOrdersScrollable()">
+          <ion-infinite-scroll @ionInfinite="loadMoreOpenOrders($event)" threshold="100px" :disabled="!isOpenOrdersScrollable()" :key="openOrders.query.queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -29,7 +29,13 @@
               <ion-badge slot="end">{{ order.orderStatusDesc }}</ion-badge>
             </ion-item>
           </ion-list>
-
+            <!--
+              When searching for a keyword, and if the user moves to the last item, then the didFire value inside infinite scroll becomes true and thus the infinite scroll does not trigger again on the same page(https://github.com/hotwax/users/issues/84).
+              In ionic v7.6.0, an issue related to infinite scroll has been fixed that when more items can be added to the DOM, but infinite scroll does not fire as the window is not completely filled with the content(https://github.com/ionic-team/ionic-framework/issues/18071).
+              The above fix in ionic 7.6.0 is resulting in the issue of infinite scroll not being called again.
+              To fix this, we have added a key with value as queryString(searched keyword), so that the infinite scroll component can be re-rendered
+              whenever the searched string is changed resulting in the correct behaviour for infinite scroll
+            -->
           <ion-infinite-scroll @ionInfinite="loadMoreTransferOrders($event)" threshold="100px" :disabled="!isTransferOrdersScrollable()" :key="transferOrders.query.queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -30,7 +30,7 @@
             </ion-item>
           </ion-list>
 
-          <ion-infinite-scroll @ionInfinite="loadMoreTransferOrders($event)" threshold="100px" :disabled="!isTransferOrdersScrollable()">
+          <ion-infinite-scroll @ionInfinite="loadMoreTransferOrders($event)" threshold="100px" :disabled="!isTransferOrdersScrollable()" :key="transferOrders.query.queryString">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289
### Short Description and Why It's Useful
In Ionic 7.6.0, an issue was fixed that caused infinite scroll to trigger when quickly scrolling or when items had not filled the entire page. This issue resulted in infinite scroll problems when used with search functionality. A key was added to the infinite scroll to trigger a re-render when the keyword is changed.



### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)