### PR TITLE
Fixed: infinite scroll issue when used with searchbar(dxp-289)

### DIFF
--- a/src/views/Completed.vue
+++ b/src/views/Completed.vue
@@ -156,7 +156,7 @@
               </div>
             </div>
           </ion-card>
-          <ion-infinite-scroll @ionInfinite="loadMoreCompletedOrders($event)" threshold="100px" v-show="isScrollingEnabled && isCompletedOrderScrollable()" ref="infiniteScrollRef">
+          <ion-infinite-scroll @ionInfinite="loadMoreCompletedOrders($event)" threshold="100px" v-show="isCompletedOrderScrollable()" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>
@@ -310,6 +310,10 @@ export default defineComponent({
       }
     },
     async loadMoreCompletedOrders(event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if (!(this.isScrollingEnabled && this.isCompletedOrderScrollable())) {
+        await event.target.complete();
+      }
       const completedOrdersQuery = JSON.parse(JSON.stringify(this.completedOrders.query))
       completedOrdersQuery.viewIndex++;
       await this.store.dispatch('order/updateCompletedOrderIndex', { ...completedOrdersQuery })

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -218,7 +218,7 @@
               </div>
             </div>
           </ion-card>
-          <ion-infinite-scroll @ionInfinite="loadMoreInProgressOrders($event)" threshold="100px"  v-show="isScrollingEnabled && isInProgressOrderScrollable()" ref="infiniteScrollRef">
+          <ion-infinite-scroll @ionInfinite="loadMoreInProgressOrders($event)" threshold="100px"  v-show="isInProgressOrderScrollable()" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>
@@ -972,6 +972,10 @@ export default defineComponent({
       }
     },
     async loadMoreInProgressOrders(event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if (!(this.isScrollingEnabled && this.isInProgressOrderScrollable())) {
+        await event.target.complete();
+      }
       const inProgressOrdersQuery = JSON.parse(JSON.stringify(this.inProgressOrders.query))
       inProgressOrdersQuery.viewIndex++;
       await this.store.dispatch('order/updateInProgressIndex', { ...inProgressOrdersQuery })

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -123,7 +123,7 @@
             </div> -->
           </ion-card>
 
-          <ion-infinite-scroll @ionInfinite="loadMoreOpenOrders($event)" threshold="100px" v-show="isScrollingEnabled && isOpenOrdersScrollable()" ref="infiniteScrollRef">
+          <ion-infinite-scroll @ionInfinite="loadMoreOpenOrders($event)" threshold="100px" v-show="isOpenOrdersScrollable()" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>
@@ -252,6 +252,10 @@ export default defineComponent({
       }
     },
     async loadMoreOpenOrders(event: any) {
+      // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+      if (!(this.isScrollingEnabled && this.isOpenOrdersScrollable())) {
+        await event.target.complete();
+      }
       const openOrdersQuery = JSON.parse(JSON.stringify(this.openOrders.query))
       openOrdersQuery.viewIndex++;
       await this.store.dispatch('order/updateOpenOrderIndex', { ...openOrdersQuery })

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -19,7 +19,7 @@
       </ion-toolbar>
     </ion-header>
     
-    <ion-content id="view-size-selector">
+    <ion-content ref="contentRef" :scroll-events="true" @ionScroll="enableScrolling()" id="view-size-selector">
       <ion-searchbar class="searchbar" :value="openOrders.query.queryString" :placeholder="translate('Search orders')" @keyup.enter="updateQueryString($event.target.value)"/>
       <div v-if="openOrders.total">
         <div class="filters">
@@ -123,7 +123,7 @@
             </div> -->
           </ion-card>
 
-          <ion-infinite-scroll @ionInfinite="loadMoreOpenOrders($event)" threshold="100px" :disabled="!isOpenOrdersScrollable()" :key="openOrders.query.queryString">
+          <ion-infinite-scroll @ionInfinite="loadMoreOpenOrders($event)" threshold="100px" v-show="isScrollingEnabled && isOpenOrdersScrollable()" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>
@@ -226,8 +226,12 @@ export default defineComponent({
   data () {
     return {
       shipmentMethods: [] as Array<any>,
-      searchedQuery: ''
+      searchedQuery: '',
+      isScrollingEnabled: false
     }
+  },
+  async ionViewWillEnter() {
+    this.isScrollingEnabled = false;
   },
   methods: {
     getErrorMessage() {
@@ -235,6 +239,17 @@ export default defineComponent({
     },
     getOpenOrders() {
       return JSON.parse(JSON.stringify(this.openOrders.list)).slice(0, (this.openOrders.query.viewIndex + 1) * (process.env.VUE_APP_VIEW_SIZE as any));
+    },
+    enableScrolling() {
+      const parentElement = (this as any).$refs.contentRef.$el
+      const scrollEl = parentElement.shadowRoot.querySelector("main[part='scroll']")
+      let scrollHeight = scrollEl.scrollHeight, infiniteHeight = (this as any).$refs.infiniteScrollRef.$el.offsetHeight, scrollTop = scrollEl.scrollTop, threshold = 100, height = scrollEl.offsetHeight
+      const distanceFromInfinite = scrollHeight - infiniteHeight - scrollTop - threshold - height
+      if(distanceFromInfinite < 0) {
+        this.isScrollingEnabled = false;
+      } else {
+        this.isScrollingEnabled = true;
+      }
     },
     async loadMoreOpenOrders(event: any) {
       const openOrdersQuery = JSON.parse(JSON.stringify(this.openOrders.query))

--- a/src/views/TransferOrders.vue
+++ b/src/views/TransferOrders.vue
@@ -38,7 +38,7 @@
                 If we do not define an extra variable and just use v-show to check for `isScrollable` then when coming back to the page infinite-scroll is called programatically.
                 We have added an ionScroll event on ionContent to check whether the infiniteScroll can be enabled or not by toggling the value of isScrollingEnabled whenever the height < 0.
               -->
-          <ion-infinite-scroll @ionInfinite="loadMoreTransferOrders($event)" threshold="100px" v-show="isScrollingEnabled && isTransferOrdersScrollable()" ref="infiniteScrollRef">
+          <ion-infinite-scroll @ionInfinite="loadMoreTransferOrders($event)" threshold="100px" v-show="isTransferOrdersScrollable()" ref="infiniteScrollRef">
             <ion-infinite-scroll-content loading-spinner="crescent" :loading-text="translate('Loading')"/>
           </ion-infinite-scroll>
         </div>
@@ -130,6 +130,10 @@ export default defineComponent({
       }
     },
     async loadMoreTransferOrders(event: any) {
+       // Added this check here as if added on infinite-scroll component the Loading content does not gets displayed
+       if (!(this.isScrollingEnabled && this.isTransferOrdersScrollable())) {
+        await event.target.complete();
+      }
       const transferOrdersQuery = JSON.parse(JSON.stringify(this.transferOrders.query))
       transferOrdersQuery.viewIndex = this.transferOrders.list?.length / (process.env.VUE_APP_VIEW_SIZE as any);
       await this.store.dispatch('transferorder/updateTransferOrderQuery', { ...transferOrdersQuery })


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

https://github.com/hotwax/dxp-components/issues/289
### Short Description and Why It's Useful
Removed the logic to re-render the infinite-scroll on queryString check that has been added in the previous PR.

Added a variable to check whether the scrolling can be enabled or not whenever users lands on the list page. For this, we have determined the height of the content part scroll and infiniteScroll component and if the height is less than 0 then only enabling the infinite-scroll component

Removed disabled as once the infiniteScroll is disabled it does not gets enabled again, hence removed the disabled property and instead used v-show to enable/disable infinite scroll.



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)