### PR TITLE
Fixed: case of api failure as the endpoints using app's domain instead of oms domain(#504)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -127,9 +127,13 @@ export default defineComponent({
       Settings.defaultZone = this.userProfile.userTimeZone;
     }
 
-    // Get product identification from api using dxp-component
-    await useProductIdentificationStore().getIdentificationPref(this.currentEComStore?.productStoreId)
-      .catch((error) => logger.error(error));
+    // If fetching identifier without checking token then on login the app stucks in a loop, as the mounted hook runs before
+    // token is available which results in api failure as unauthenticated, thus making logout call and then login call again and so on.
+    if(this.userToken) {
+      // Get product identification from api using dxp-component
+      await useProductIdentificationStore().getIdentificationPref(this.currentEComStore?.productStoreId)
+        .catch((error) => logger.error(error));
+    }
   },
   unmounted() {
     emitter.off('presentLoader', this.presentLoader);

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -84,17 +84,13 @@ const actions: ActionTree<UserState, RootState> = {
         const store = userProfile.stores.find((store: any) => store.productStoreId === preferredStoreId);
         store && (preferredStore = store)
       }
-
-      // Get product identification from api using dxp-component
-      await useProductIdentificationStore().getIdentificationPref(preferredStoreId ? preferredStoreId : preferredStore.productStoreId)
-        .catch((error) => logger.error(error));
-
       /*  ---- Guard clauses ends here --- */
 
       setPermissions(appPermissions);
       if (userProfile.userTimeZone) {
         Settings.defaultZone = userProfile.userTimeZone;
       }
+      updateToken(token)
 
       dispatch('getFieldMappings')
 
@@ -104,7 +100,11 @@ const actions: ActionTree<UserState, RootState> = {
       commit(types.USER_INFO_UPDATED, userProfile);
       commit(types.USER_PERMISSIONS_UPDATED, appPermissions);
       commit(types.USER_TOKEN_CHANGED, { newToken: token })
-      updateToken(token)
+
+      // Get product identification from api using dxp-component
+      await useProductIdentificationStore().getIdentificationPref(preferredStoreId ? preferredStoreId : preferredStore.productStoreId)
+        .catch((error) => logger.error(error));
+
       this.dispatch('util/findProductStoreShipmentMethCount')
     } catch (err: any) {
       // If any of the API call in try block has status code other than 2xx it will be handled in common catch block.


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->
Related Issue #504 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
When making api call to fetch identification for products it gets failed as unauthorized as the token is not set till the api call. As the api fails, it clears the oms-url and as the apps flow does not break for this api failure some other apis gets called with the app's url instead of oms-url.

Moved the logic to update the token to handle the api failure case so that endpoints will not be prepared for app. Also added a check on app's mount that the identification method should only be called if we have a token available.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)