### PR TITLE
Fixed: On reject, the alert will close, and the loader will be displayed(#512)

### DIFF
--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -1143,8 +1143,8 @@ export default defineComponent({
         }, {
           text: translate('Reject'),
           handler: async () => {
-            await alert.dismiss()
-            emitter.emit("presentLoader")
+            emitter.emit("presentLoader")  
+            await alert.dismiss()  
 
             let resp;
 

--- a/src/views/InProgress.vue
+++ b/src/views/InProgress.vue
@@ -1143,6 +1143,9 @@ export default defineComponent({
         }, {
           text: translate('Reject'),
           handler: async () => {
+            await alert.dismiss()
+            emitter.emit("presentLoader")
+
             let resp;
 
             try {
@@ -1161,6 +1164,7 @@ export default defineComponent({
               showToast(translate('Failed to reject in progress orders'))
               logger.error('Failed to reject in progress orders', err)
             }
+            emitter.emit("dismissLoader")
           }
         }]
       });

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -360,8 +360,8 @@ export default defineComponent({
         }, {
           text: translate('Reject'),
           handler: async () => {
-            await alert.dismiss()
             emitter.emit("presentLoader")
+            await alert.dismiss()
             
             let resp;
 

--- a/src/views/OpenOrders.vue
+++ b/src/views/OpenOrders.vue
@@ -360,6 +360,9 @@ export default defineComponent({
         }, {
           text: translate('Reject'),
           handler: async () => {
+            await alert.dismiss()
+            emitter.emit("presentLoader")
+            
             let resp;
 
             try {
@@ -378,6 +381,7 @@ export default defineComponent({
               showToast(translate('Failed to reject outstanding orders'))
               logger.error('Failed to reject outstanding orders', err)
             }
+            emitter.emit("dismissLoader")
           }
         }]
       });


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#512 
### Short Description and Why It's Useful
- Added snippet to `dismiss` the alert box after rejecting.
- Added `loader` after dismissing the alert until the `API` completes."


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)