### PR TITLE
Fixed: Product store shipment method association logic to persist the state of each product store (#493).

### DIFF
--- a/src/store/modules/carrier/actions.ts
+++ b/src/store/modules/carrier/actions.ts
@@ -178,16 +178,16 @@ const actions: ActionTree<CarrierState, RootState> = {
   },
   checkAssociatedProductStoreShipmentMethods({ state, dispatch }) {
     const currentCarrier = state.current;
-    const carrierShipmentMethods = currentCarrier.shipmentMethods;
-    const carrierProductStoreShipmentMethods = currentCarrier.productStoreShipmentMethods;
+    const carrierShipmentMethods = JSON.parse(JSON.stringify(currentCarrier.shipmentMethods));
+    const carrierProductStoreShipmentMethods = JSON.parse(JSON.stringify(currentCarrier.productStoreShipmentMethods));
     const productStores = store.getters['util/getProductStores'];
     const carrierShipmentMethodsByProductStore = {} as any;
     const productStoreShipmentMethodFields = ["description", "productStoreId", "isTrackingRequired", "shipmentGatewayConfigId", "productStoreShipMethId"]
 
     if (carrierShipmentMethods) {
       productStores.forEach((productStore: any) => {
-        Object.values(carrierShipmentMethods).forEach((shipmentMethod: any) => {
-          if (carrierProductStoreShipmentMethods && carrierProductStoreShipmentMethods[productStore.productStoreId][shipmentMethod.shipmentMethodTypeId]) {
+        JSON.parse(JSON.stringify(Object.values(carrierShipmentMethods))).forEach((shipmentMethod: any) => {
+          if (carrierProductStoreShipmentMethods && carrierProductStoreShipmentMethods?.[productStore.productStoreId]?.[shipmentMethod.shipmentMethodTypeId]) {
               const productStoreShipmentMethod = carrierProductStoreShipmentMethods[productStore.productStoreId][shipmentMethod.shipmentMethodTypeId];
               shipmentMethod.isChecked = true;
               productStoreShipmentMethodFields.forEach((field) => {
@@ -205,9 +205,9 @@ const actions: ActionTree<CarrierState, RootState> = {
           }
           
           if (carrierShipmentMethodsByProductStore[productStore.productStoreId]) {
-              carrierShipmentMethodsByProductStore[productStore.productStoreId].push(shipmentMethod);
+            carrierShipmentMethodsByProductStore[productStore.productStoreId].push(shipmentMethod);
           } else {
-              carrierShipmentMethodsByProductStore[productStore.productStoreId] = [shipmentMethod];
+            carrierShipmentMethodsByProductStore[productStore.productStoreId] = [shipmentMethod];
           }
         });
       });

--- a/src/views/CarrierDetail.vue
+++ b/src/views/CarrierDetail.vue
@@ -83,7 +83,7 @@
                       <ion-note class="config-label">{{ translate('gateway') }}</ion-note>
                     </div>
                     <div class="tablet">
-                      <ion-toggle v-model="shipmentMethod.isTrackingRequired" :disabled="!shipmentMethod.isChecked" @ionChange="updateTrackingRequired($event, shipmentMethod)"/>
+                      <ion-toggle :checked="shipmentMethod.isTrackingRequired" :disabled="!shipmentMethod.isChecked" @ionChange="updateTrackingRequired($event, shipmentMethod)"/>
                       <ion-note class="config-label">{{ translate("require tracking code") }}</ion-note>
                     </div>
                     <div class="tablet">
@@ -342,7 +342,7 @@
 
       async updateTrackingRequired(event: any, shipmentMethod: any) {
         event.stopPropagation();
-        const modifiedData = {"fieldName": "isTrackingRequired", "fieldValue": shipmentMethod.isTrackingRequired}
+        const modifiedData = {"fieldName": "isTrackingRequired", "fieldValue": shipmentMethod.isTrackingRequired ? false : true}
         const messages = {"successMessage": "Tracking code settings updated successfully.", "errorMessage": "Failed to update tracking code settings."}
         this.updateProductStoreShipmentMethod(shipmentMethod, modifiedData, messages)
       },
@@ -363,8 +363,8 @@
               if (!hasError(resp)) {
                 showToast(translate(messages.successMessage))
                 productStoreShipmentMethods[shipmentMethod.productStoreId][shipmentMethod.shipmentMethodTypeId] = {...shipmentMethod, [modifiedData.fieldName]: modifiedData.fieldValue}
-                this.store.dispatch('carrier/updateCurrentCarrierProductStoreShipmentMethods', productStoreShipmentMethods)
-                this.store.dispatch('carrier/checkAssociatedProductStoreShipmentMethods')
+                await this.store.dispatch('carrier/updateCurrentCarrierProductStoreShipmentMethods', productStoreShipmentMethods)
+                await this.store.dispatch('carrier/checkAssociatedProductStoreShipmentMethods')
               } else {
                 throw resp.data;
               }


### PR DESCRIPTION


### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Fixed: Product store shipment method association logic to persist the state of each product store (#493).

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)