### PR TITLE
Fixed: change the position of the 'ref' in ion-input(#557)

### DIFF
--- a/src/components/TransferOrderItem.vue
+++ b/src/components/TransferOrderItem.vue
@@ -14,8 +14,8 @@
         </ion-item>
       </div>
       <div class="product-count">
-        <ion-item v-if="!item.shipmentId" ref="pickedQuantity" lines="none">
-          <ion-input :label="translate('Qty')" label-placement="floating" type="number" min="0" v-model="item.pickedQuantity" @ionChange="updatePickedQuantity($event, item)" @ionInput="validatePickedQuantity($event, item)" @ionBlur="markPickedQuantityTouched" :errorText="getErrorText(item)" />
+        <ion-item v-if="!item.shipmentId" lines="none">
+          <ion-input :label="translate('Qty')" label-placement="floating" ref="pickedQuantity" type="number" min="0" v-model="item.pickedQuantity" @ionChange="updatePickedQuantity($event, item)" @ionInput="validatePickedQuantity($event, item)" @ionBlur="markPickedQuantityTouched" :errorText="getErrorText(item)" />
         </ion-item>
         <ion-item v-else lines="none">
           <ion-label slot="end">{{ item.pickedQuantity }} {{ translate('packed') }}</ion-label>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#557 
### Short Description and Why It's Useful
- Changed the position of `pickedQuantity` (`ref`)  from ion-item to ion-input.
### Screenshots of Visual Changes before/after (If There Are Any)
![Screenshot from 2024-05-22 17-51-12](https://github.com/hotwax/fulfillment-pwa/assets/89250683/21370696-05f7-4ee3-b220-669e152bd55e)


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/ionic-bopis#contribution-guideline)